### PR TITLE
Unify error responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: lint
 
 # Generate GRPC client/server, openapi spec, http server
 ${PROTO_DIR}/%_openapi.yaml ${GEN_DIR}/%.pb.go ${GEN_DIR}/%.pb.gw.go: ${PROTO_DIR}/%.proto
-	protoc -I. --openapi_out=${API_DIR} --openapi_opt=naming=proto \
+	protoc -I. --openapi_out=${API_DIR} --openapi_opt=naming=proto,enum_type=string \
 		--go_out=${API_DIR} --go_opt=paths=source_relative \
 		--go-grpc_out=${API_DIR} --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
 		--grpc-gateway_out=${API_DIR} --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
@@ -24,7 +24,7 @@ ${PROTO_DIR}/%_openapi.yaml ${GEN_DIR}/%.pb.go ${GEN_DIR}/%.pb.gw.go: ${PROTO_DI
 # generate Go HTTP client from openapi spec
 ${API_DIR}/client/${V}/%/http.go: ${PROTO_DIR}/%_openapi.yaml
 	mkdir -p ${API_DIR}/client/${V}/$(*F)
-	oapi-codegen -package api -generate "client, types, spec" \
+	oapi-codegen --old-config-style -package api -generate "client, types, spec" \
 		-o ${API_DIR}/client/${V}/$(*F)/http.go \
 		${PROTO_DIR}/$(*F)_openapi.yaml
 

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -17,11 +17,11 @@ set -ex
 
 export GO111MODULE=on
 
-go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
-go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.7
-go install github.com/google/gnostic/cmd/protoc-gen-openapi@v0.6 #generate openapi 3.0 spec
-go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.10 #generate go http client
+go install google.golang.org/protobuf/cmd/protoc-gen-go@v1
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1
+go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2
+go install github.com/google/gnostic/cmd/protoc-gen-openapi@v0 #generate openapi 3.0 spec
+go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1 #generate go http client
 go install github.com/mikefarah/yq/v4@latest # used to fix OpenAPI spec in scripts/fix_openapi.sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/server/v1/api.proto
+++ b/server/v1/api.proto
@@ -23,9 +23,6 @@ import "openapiv3/annotations.proto";
 option go_package = "github.com/tigrisdata/tigris/api";
 option java_package = "com.tigrisdata.db.api.v1.grpc";
 
-// BUG: gnostic protoc-gen-openapi doesn't support enum generation
-// https://github.com/google/gnostic/issues/255
-
 option (openapi.v3.document) = {
   info: {
     title: "Tigris API Reference"
@@ -72,9 +69,53 @@ option (openapi.v3.document) = {
   }
 };
 
+// Codes returned by the Tigris server in the case of error
+enum Code {
+  OK = 0; // 200
+  CANCELLED = 1; // 499
+  UNKNOWN = 2; // 500
+  INVALID_ARGUMENT = 3; // 400
+  DEADLINE_EXCEEDED = 4; // 504
+  NOT_FOUND = 5; // 404
+  ALREADY_EXISTS = 6; // 409
+  PERMISSION_DENIED = 7; // 403
+  RESOURCE_EXHAUSTED = 8; // 429
+  FAILED_PRECONDITION = 9; // 400
+  ABORTED = 10; // 409
+  OUT_OF_RANGE = 11; // 400
+  UNIMPLEMENTED = 12; // 501
+  INTERNAL = 13; // 500
+  UNAVAILABLE = 14; // 503
+  DATA_LOSS = 15; // 500
+  UNAUTHENTICATED = 16; // 401
+
+  // Above code are identical to GRPC standard codes: https://cloud.google.com/apis/design/errors
+  // Below Tigris specific extended error codes are defined:
+
+  CONFLICT = 17; // 409
+}
+
+// Contains retry information
+message RetryInfo {
+  // retry delay advice in milliseconds
+  int32 delay = 3;
+}
+
+// ErrorDetails defines error format passed by Tigris HTTP protocol
 message ErrorDetails {
-  uint32 code = 1;
-  string msg = 2;
+  string code = 1;
+  string message = 2;
+  RetryInfo retry = 3;
+}
+
+// The Error type defines a logical error model
+message Error {
+  // The status code is a short, machine parsable string,
+  // which uniquely identifies the error type.
+  // Tigris to HTTP code mapping [here](/reference/http-code)
+  Code code = 1;
+  // A developer-facing descriptive error message
+  string message = 2;
 }
 
 // Additional options to modify write requests.
@@ -512,10 +553,13 @@ message StreamEvent {
 }
 
 message GetInfoRequest {
-
 }
+
 message GetInfoResponse {
   string server_version = 1;
+
+  // NOTE: This is a hack to propagate this object definition to OpenAPI
+  Error error = 2;
 }
 
 service Tigris {

--- a/server/v1/api_openapi.yaml
+++ b/server/v1/api_openapi.yaml
@@ -257,7 +257,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/ReadResponse'
+                                $ref: '#/components/schemas/StreamingReadResponse'
                 default:
                     description: Default error response
                     content:
@@ -509,7 +509,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/StreamResponse'
+                                $ref: '#/components/schemas/StreamingStreamResponse'
                 default:
                     description: Default error response
                     content:
@@ -836,6 +836,36 @@ components:
                 status:
                     type: string
                     description: An enum with value set as "dropped".
+        Error:
+            type: object
+            properties:
+                code:
+                    enum:
+                        - OK
+                        - CANCELLED
+                        - UNKNOWN
+                        - INVALID_ARGUMENT
+                        - DEADLINE_EXCEEDED
+                        - NOT_FOUND
+                        - ALREADY_EXISTS
+                        - PERMISSION_DENIED
+                        - RESOURCE_EXHAUSTED
+                        - FAILED_PRECONDITION
+                        - ABORTED
+                        - OUT_OF_RANGE
+                        - UNIMPLEMENTED
+                        - INTERNAL
+                        - UNAVAILABLE
+                        - DATA_LOSS
+                        - UNAUTHENTICATED
+                        - CONFLICT
+                    type: string
+                    description: The status code is a short, machine parsable string, which uniquely identifies the error type. Tigris to HTTP code mapping [here](/reference/http-code)
+                    format: enum
+                message:
+                    type: string
+                    description: A developer-facing descriptive error message
+            description: The Error type defines a logical error model
         GetInfoResponse:
             type: object
             properties:
@@ -1002,22 +1032,6 @@ components:
                 status:
                     type: string
                     description: Status of rollback transaction operation.
-        Status:
-            type: object
-            properties:
-                code:
-                    type: integer
-                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-                    format: int32
-                message:
-                    type: string
-                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-                details:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/GoogleProtobufAny'
-                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
-            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
         StreamEvent:
             type: object
             properties:
@@ -1107,6 +1121,25 @@ components:
                 tx_ctx:
                     $ref: '#/components/schemas/TransactionCtx'
             description: Additional options to modify write requests.
+        StreamingReadResponse:
+            type: object
+            properties:
+                result:
+                    $ref: '#/components/schemas/ReadResponse'
+                error:
+                    $ref: '#/components/schemas/Error'
+        StreamingStreamResponse:
+            type: object
+            properties:
+                result:
+                    $ref: '#/components/schemas/StreamResponse'
+                error:
+                    $ref: '#/components/schemas/Error'
+        Status:
+            type: object
+            properties:
+                error:
+                    $ref: '#/components/schemas/Error'
     securitySchemes:
         BearerAuth:
             type: http


### PR DESCRIPTION
* HTTP error code returned as string
* Enum for the extended codes defined
* Streaming error responses are unified

Earlier unary requests returned errors as:
```
{"code":2,"message":"errror message"}
```
But streaming responses were returned as:
```
{"error":{"code":2,"message":"errror message"}}
```
This diff unifies this and makes all requests to return
the error in the following format:
```
{"error":{"code":2,"message":"errror message"}}
```