### PR TITLE
feat: /v1/search request/response definition

### DIFF
--- a/server/v1/api.proto
+++ b/server/v1/api.proto
@@ -345,6 +345,70 @@ message ReadResponse {
   // Has metadata related to the documents stored.
   ResponseMetadata metadata = 3;
 }
+message SearchRequest {
+  // Database name to read documents from.
+  string db = 1;
+  // Collection name to read documents from.
+  string collection = 2;
+  // Query string for searching across text fields
+  string q = 3;
+  // Array of fields to project search query against
+  repeated string search_fields = 4;
+  // Filter stacks on top of query results to further narrow down the results. Similar to `ReadRequest.filter`
+  bytes filter = 5;
+  // Facet query to aggregate results on given fields
+  bytes facet = 6;
+  // Array of fields and corresponding sort orders to order the results `[{ "salary": "$desc" }]`
+  bytes sort = 7;
+  // Fetch specific fields from a document. Default is all
+  bytes fields = 8;
+}
+
+// Response struct for /search
+message SearchResponse {
+  repeated SearchHit hits = 1;
+  map<string, SearchFacet> facets = 2;
+  SearchMetadata meta = 3;
+}
+
+message SearchHit {
+  // actual search document
+  bytes data = 1;
+  SearchHitMeta meta = 2;
+}
+
+message SearchHitMeta {}
+
+message SearchFacet {
+  repeated FacetCount counts = 1;
+  FacetStats stats = 2;
+}
+
+message FacetCount {
+  int64 count = 1;
+  string value = 2;
+}
+
+// avg, min, max, sum are only available for numeric fields
+message FacetStats {
+  float avg = 1;
+  int64 max = 2;
+  int64 min = 3;
+  int64 sum = 4;
+  int64 total_values = 5;
+}
+
+message SearchMetadata {
+  int64 found = 1;
+  Page page = 2;
+}
+
+// Pagination meta. Used only in /search as of now
+message Page {
+  int64 current = 1;
+  int64 total_pages = 2;
+  int32 per_page = 3;
+}
 
 message CreateDatabaseRequest {
   // Create database with this name.
@@ -655,6 +719,18 @@ service Tigris {
     };
     option(openapi.v3.operation) = {
       summary: "Read Documents"
+      tags: "Documents"
+    };
+  }
+
+  //  Searches a collection for documents matching the query
+  rpc Search(SearchRequest) returns (stream SearchResponse) {
+    option (google.api.http) = {
+      post : "/api/v1/databases/{db}/collections/{collection}/documents/search"
+      body : "*"
+    };
+    option(openapi.v3.operation) = {
+      summary: "Search Documents"
       tags: "Documents"
     };
   }

--- a/server/v1/api_openapi.yaml
+++ b/server/v1/api_openapi.yaml
@@ -303,6 +303,45 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
+    /api/v1/databases/{db}/collections/{collection}/documents/search:
+        post:
+            tags:
+                - Documents
+            summary: Search Documents
+            description: Searches a collection for documents matching the query
+            operationId: Tigris_Search
+            parameters:
+                - name: db
+                  in: path
+                  description: Database name to read documents from.
+                  required: true
+                  schema:
+                    type: string
+                - name: collection
+                  in: path
+                  description: Collection name to read documents from.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SearchRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SearchResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
     /api/v1/databases/{db}/collections/{collection}/documents/update:
         put:
             tags:
@@ -867,6 +906,33 @@ components:
                     type: string
                     description: A developer-facing descriptive error message
             description: The Error type defines a logical error model
+        FacetCount:
+            type: object
+            properties:
+                count:
+                    type: integer
+                    format: int64
+                value:
+                    type: string
+        FacetStats:
+            type: object
+            properties:
+                avg:
+                    type: number
+                    format: float
+                max:
+                    type: integer
+                    format: int64
+                min:
+                    type: integer
+                    format: int64
+                sum:
+                    type: integer
+                    format: int64
+                total_values:
+                    type: integer
+                    format: int64
+            description: avg, min, max, sum are only available for numeric fields
         GetInfoResponse:
             type: object
             properties:
@@ -934,6 +1000,19 @@ components:
                     items:
                         $ref: '#/components/schemas/DatabaseInfo'
                     description: List of the databases.
+        Page:
+            type: object
+            properties:
+                current:
+                    type: integer
+                    format: int64
+                total_pages:
+                    type: integer
+                    format: int64
+                per_page:
+                    type: integer
+                    format: int32
+            description: Pagination meta. Used only in /search as of now
         ReadRequest:
             type: object
             properties:
@@ -1033,6 +1112,82 @@ components:
                 status:
                     type: string
                     description: Status of rollback transaction operation.
+        SearchFacet:
+            type: object
+            properties:
+                counts:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/FacetCount'
+                stats:
+                    $ref: '#/components/schemas/FacetStats'
+        SearchHit:
+            type: object
+            properties:
+                data:
+                    type: string
+                    description: actual search document
+                    format: byte
+                meta:
+                    $ref: '#/components/schemas/SearchHitMeta'
+        SearchHitMeta:
+            type: object
+            properties: {}
+        SearchMetadata:
+            type: object
+            properties:
+                found:
+                    type: integer
+                    format: int64
+                page:
+                    $ref: '#/components/schemas/Page'
+        SearchRequest:
+            type: object
+            properties:
+                db:
+                    type: string
+                    description: Database name to read documents from.
+                collection:
+                    type: string
+                    description: Collection name to read documents from.
+                q:
+                    type: string
+                    description: Query string for searching across text fields
+                search_fields:
+                    type: array
+                    items:
+                        type: string
+                    description: Array of fields to project search query against
+                filter:
+                    type: string
+                    description: Filter stacks on top of query results to further narrow down the results. Similar to `ReadRequest.filter`
+                    format: byte
+                facet:
+                    type: string
+                    description: Facet query to aggregate results on given fields
+                    format: byte
+                sort:
+                    type: string
+                    description: 'Array of fields and corresponding sort orders to order the results `[{ "salary": "$desc" }]`'
+                    format: byte
+                fields:
+                    type: string
+                    description: Fetch specific fields from a document. Default is all
+                    format: byte
+        SearchResponse:
+            type: object
+            properties:
+                hits:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SearchHit'
+                facets:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/SearchFacet'
+                meta:
+                    $ref: '#/components/schemas/SearchMetadata'
+            description: Response struct for /search
         StreamEvent:
             type: object
             properties:


### PR DESCRIPTION
### Search Request
```json
{
  "q": "Steve",
  "search_fields": [
    "first_name",
    "last_name"
  ],
  "filter": {
    "$or": [
      {
        "country": {
          "$eq": "USA"
        }
      },
      {
        "country": "UK"
      }
    ],
    "$and": [
      {
        "last_name": {
          "$ne": "Ballmer"
        }
      },
      {
        "last_updated": {
          "$gte": "2018-10-29 10:02:48"
        }
      },
      {
        "last_updated": {
          "$lt": "2020-10-29 10:02:48"
        }
      }
    ]
  },
  "facet": {},
  "sort": [
    {
      "age": "$asc"
    },
    {
      "salary": "$desc"
    }
  ],
  "fields": []
}
```

### Search Response
```json
{
  "hits": [
    {
      "doc": {},
      "meta": {}
    }
  ],
  "facet": {
    "field": {
      "counts": [],
      "stats": {}
    }
  },
  "meta": {
    "found": 12345,
    "page": {
      "current": 1,
      "total_pages": 5,
      "per_page": 10
    }
  }
}
```

Most of the request is open ended as of now and `pagination` input is not finalized yet.