### PR TITLE
fix: replaced object for bytes in openapi spec for /search

### DIFF
--- a/scripts/fix_openapi.sh
+++ b/scripts/fix_openapi.sh
@@ -113,6 +113,9 @@ yq_fix_object ReplaceRequest documents.items
 yq_fix_object UpdateRequest fields
 yq_fix_object ReadRequest fields
 yq_fix_object ReadResponse data
+yq_fix_object SearchRequest fields
+yq_fix_object SearchRequest facet
+yq_fix_object SearchHit data
 yq_fix_object CreateOrUpdateCollectionRequest schema
 yq_fix_object StreamEvent data
 yq_fix_timestamp ResponseMetadata created_at
@@ -126,13 +129,14 @@ yq_del_service_tags
 for i in InsertRequest ReplaceRequest UpdateRequest DeleteRequest ReadRequest \
 	CreateOrUpdateCollectionRequest DropCollectionRequest \
 	CreateDatabaseRequest DropDatabaseRequest \
-	ListDatabasesRequest ListCollectionsRequest \
+	ListDatabasesRequest ListCollectionsRequest SearchRequest \
 	BeginTransactionRequest CommitTransactionRequest RollbackTransactionRequest; do
 
 	yq_del_db_coll $i
 done
 
 yq_streaming_response ReadResponse "collections/{collection}/documents/read"
+yq_streaming_response SearchResponse "collections/{collection}/documents/search"
 yq_streaming_response StreamResponse stream
 
 yq_error_response

--- a/server/v1/api.proto
+++ b/server/v1/api.proto
@@ -395,7 +395,7 @@ message FacetStats {
   int64 max = 2;
   int64 min = 3;
   int64 sum = 4;
-  int64 total_values = 5;
+  int64 count = 5;
 }
 
 message SearchMetadata {
@@ -406,7 +406,7 @@ message SearchMetadata {
 // Pagination meta. Used only in /search as of now
 message Page {
   int64 current = 1;
-  int64 total_pages = 2;
+  int64 total = 2;
   int32 per_page = 3;
 }
 

--- a/server/v1/api_openapi.yaml
+++ b/server/v1/api_openapi.yaml
@@ -335,7 +335,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/SearchResponse'
+                                $ref: '#/components/schemas/StreamingSearchResponse'
                 default:
                     description: Default error response
                     content:
@@ -929,7 +929,7 @@ components:
                 sum:
                     type: integer
                     format: int64
-                total_values:
+                count:
                     type: integer
                     format: int64
             description: avg, min, max, sum are only available for numeric fields
@@ -1006,7 +1006,7 @@ components:
                 current:
                     type: integer
                     format: int64
-                total_pages:
+                total:
                     type: integer
                     format: int64
                 per_page:
@@ -1125,9 +1125,8 @@ components:
             type: object
             properties:
                 data:
-                    type: string
+                    type: object
                     description: actual search document
-                    format: byte
                 meta:
                     $ref: '#/components/schemas/SearchHitMeta'
         SearchHitMeta:
@@ -1144,12 +1143,6 @@ components:
         SearchRequest:
             type: object
             properties:
-                db:
-                    type: string
-                    description: Database name to read documents from.
-                collection:
-                    type: string
-                    description: Collection name to read documents from.
                 q:
                     type: string
                     description: Query string for searching across text fields
@@ -1163,17 +1156,15 @@ components:
                     description: Filter stacks on top of query results to further narrow down the results. Similar to `ReadRequest.filter`
                     format: byte
                 facet:
-                    type: string
+                    type: object
                     description: Facet query to aggregate results on given fields
-                    format: byte
                 sort:
                     type: string
                     description: 'Array of fields and corresponding sort orders to order the results `[{ "salary": "$desc" }]`'
                     format: byte
                 fields:
-                    type: string
+                    type: object
                     description: Fetch specific fields from a document. Default is all
-                    format: byte
         SearchResponse:
             type: object
             properties:
@@ -1282,6 +1273,13 @@ components:
             properties:
                 result:
                     $ref: '#/components/schemas/ReadResponse'
+                error:
+                    $ref: '#/components/schemas/Error'
+        StreamingSearchResponse:
+            type: object
+            properties:
+                result:
+                    $ref: '#/components/schemas/SearchResponse'
                 error:
                     $ref: '#/components/schemas/Error'
         StreamingStreamResponse:


### PR DESCRIPTION
Marked `SearchRequest.fields`, `SearchRequest.facet`, `SearchHit.data` as `object`