### PR TITLE
Transactions context removed from the request body

### DIFF
--- a/server/v1/api.proto
+++ b/server/v1/api.proto
@@ -121,15 +121,11 @@ message Error {
 
 // Additional options to modify write requests.
 message WriteOptions {
-  // Perform operation in the context of this transaction.
-  TransactionCtx tx_ctx = 1;
 }
 
 // Options that can be used to modify the results, for example "limit" to control the number of documents
 // returned by the server.
 message ReadRequestOptions {
-  // Perform operation in the context of this transaction.
-  TransactionCtx tx_ctx = 1;
   // Limit the number of documents returned by the read operation.
   int64 limit = 2;
   // Number of documents to skip before starting to return resulting documents.
@@ -143,8 +139,6 @@ message DatabaseOptions {}
 
 // Collection requests modifying options.
 message CollectionOptions {
-  // Perform operation in the context of this transaction.
-  TransactionCtx tx_ctx = 1;
 }
 
 // Options that can be used to modify the transaction semantics.
@@ -152,8 +146,8 @@ message TransactionOptions {}
 
 // Contains ID which uniquely identifies transaction
 // This context is returned by BeginTransaction request and
-// should be passed in the subsequent requests in order to run
-// them in the context of the same transaction.
+// should be passed in the metadata (headers) of subsequent requests
+// in order to run them in the context of the same transaction.
 message TransactionCtx {
   // Unique for a single transactional request.
   string id = 1;
@@ -180,8 +174,6 @@ message BeginTransactionResponse {
 message CommitTransactionRequest {
   // Database name this transaction belongs to.
   string db = 1;
-  // Tigris transactional context with details about the transactions.
-  TransactionCtx tx_ctx = 2;
 }
 message CommitTransactionResponse {
   // Status of commit transaction operation.
@@ -192,8 +184,6 @@ message CommitTransactionResponse {
 message RollbackTransactionRequest {
   // Database name this transaction belongs to.
   string db = 1;
-  // Tigris transactional context with details about the transactions.
-  TransactionCtx tx_ctx = 2;
 }
 message RollbackTransactionResponse {
   // Status of rollback transaction operation.

--- a/server/v1/api_openapi.yaml
+++ b/server/v1/api_openapi.yaml
@@ -795,15 +795,11 @@ components:
             properties: {}
         CollectionOptions:
             type: object
-            properties:
-                tx_ctx:
-                    $ref: '#/components/schemas/TransactionCtx'
+            properties: {}
             description: Collection requests modifying options.
         CommitTransactionRequest:
             type: object
-            properties:
-                tx_ctx:
-                    $ref: '#/components/schemas/TransactionCtx'
+            properties: {}
             description: Commit transaction with the given ID
         CommitTransactionResponse:
             type: object
@@ -1141,8 +1137,6 @@ components:
         ReadRequestOptions:
             type: object
             properties:
-                tx_ctx:
-                    $ref: '#/components/schemas/TransactionCtx'
                 limit:
                     type: integer
                     description: Limit the number of documents returned by the read operation.
@@ -1216,9 +1210,7 @@ components:
             description: Has metadata related to the documents stored.
         RollbackTransactionRequest:
             type: object
-            properties:
-                tx_ctx:
-                    $ref: '#/components/schemas/TransactionCtx'
+            properties: {}
             description: Rollback transaction with the given ID
         RollbackTransactionResponse:
             type: object
@@ -1359,7 +1351,7 @@ components:
                 origin:
                     type: string
                     description: Serves as an internal identifier.
-            description: Contains ID which uniquely identifies transaction This context is returned by BeginTransaction request and should be passed in the subsequent requests in order to run them in the context of the same transaction.
+            description: Contains ID which uniquely identifies transaction This context is returned by BeginTransaction request and should be passed in the metadata (headers) of subsequent requests in order to run them in the context of the same transaction.
         TransactionOptions:
             type: object
             properties: {}
@@ -1395,9 +1387,7 @@ components:
                     description: an enum with value set as "updated".
         WriteOptions:
             type: object
-            properties:
-                tx_ctx:
-                    $ref: '#/components/schemas/TransactionCtx'
+            properties: {}
             description: Additional options to modify write requests.
         StreamingReadResponse:
             type: object


### PR DESCRIPTION
BREAKING CHANGE: Transactions context removed from the request body