### PR TITLE
Simplify generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ all: lint
 
 .PRECIOUS: ${PROTO_DIR}/%_openapi.yaml ${PROTO_DIR}/%.proto
 
+COMPONENTS = api health admin auth
+
 # Generate GRPC client/server, openapi spec, http server
 ${PROTO_DIR}/%_openapi.yaml ${GEN_DIR}/%.pb.go ${GEN_DIR}/%.pb.gw.go: ${PROTO_DIR}/%.proto
 	protoc -I. --openapi_out=${API_DIR} --openapi_opt=naming=proto,enum_type=string \
@@ -28,10 +30,10 @@ ${API_DIR}/client/${V}/%/http.go: ${PROTO_DIR}/%_openapi.yaml
 		-o ${API_DIR}/client/${V}/$(*F)/http.go \
 		${PROTO_DIR}/$(*F)_openapi.yaml
 
-generate: ${GEN_DIR}/api.pb.go ${GEN_DIR}/api.pb.gw.go ${PROTO_DIR}/api_openapi.yaml \
-${GEN_DIR}/health.pb.go ${GEN_DIR}/health.pb.gw.go ${PROTO_DIR}/health_openapi.yaml \
-${GEN_DIR}/admin.pb.go ${GEN_DIR}/admin.pb.gw.go ${PROTO_DIR}/admin_openapi.yaml \
-${GEN_DIR}/auth.pb.go ${GEN_DIR}/auth.pb.gw.go ${PROTO_DIR}/auth_openapi.yaml
+generate: \
+	$(COMPONENTS:%=$(GEN_DIR)/%.pb.go) \
+	$(COMPONENTS:%=$(GEN_DIR)/%.pb.gw.go) \
+	$(COMPONENTS:%=$(PROTO_DIR)/%_openapi.yaml)
 
 client: ${API_DIR}/client/${V}/api/http.go
 


### PR DESCRIPTION
Simplifies the `generate` target by using string operations as it has been bugging my beak. :- )

# Test with original
```
❯ make generate --debug
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.3.0
Reading makefiles...
Updating goal targets....
 File `generate' does not exist.
   File `server/v1/api.pb.go' does not exist.
  Must remake target `server/v1/api.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/api.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/api_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/api.pb.go'.
   File `server/v1/health.pb.go' does not exist.
  Must remake target `server/v1/health.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/health.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/health_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/health.pb.go'.
   File `server/v1/admin.pb.go' does not exist.
  Must remake target `server/v1/admin.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/admin.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/admin_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/admin.pb.go'.
   File `server/v1/auth.pb.go' does not exist.
  Must remake target `server/v1/auth.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/auth.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/auth_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/auth.pb.go'.
Must remake target `generate'.
Successfully remade target file `generate'.
```

# Test with new
```
❯ make generate_new --debug
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.3.0
Reading makefiles...
Updating goal targets....
 File `generate_new' does not exist.
   File `server/v1/api.pb.go' does not exist.
  Must remake target `server/v1/api.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/api.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/api_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/api.pb.go'.
   File `server/v1/health.pb.go' does not exist.
  Must remake target `server/v1/health.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/health.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/health_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/health.pb.go'.
   File `server/v1/admin.pb.go' does not exist.
  Must remake target `server/v1/admin.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/admin.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/admin_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/admin.pb.go'.
   File `server/v1/auth.pb.go' does not exist.
  Must remake target `server/v1/auth.pb.go'.
protoc -I. --openapi_out=. --openapi_opt=naming=proto,enum_type=string \
		--go_out=. --go_opt=paths=source_relative \
		--go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
		--grpc-gateway_out=. --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \
		server/v1/auth.proto
/bin/bash scripts/fix_openapi.sh ./openapi.yaml server/v1/auth_openapi.yaml
rm ./openapi.yaml
  Successfully remade target file `server/v1/auth.pb.go'.
Must remake target `generate_new'.
Successfully remade target file `generate_new'.
```

A `make clean` was run before each test.