### PR TITLE
refactor: Facet stats to have optional attributes for numeric fields

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ on:
         required: true
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ all: lint
 COMPONENTS = api health admin auth observability
 
 # Generate GRPC client/server, openapi spec, http server
+# Note: --experimental_allow_proto3_optional flag could be removed once protobuf-compiler used by gh action is upgraded to 3.15+
+# 		it is currently at 3.12 and requires passing this flag
 ${PROTO_DIR}/%_openapi.yaml ${GEN_DIR}/%.pb.go ${GEN_DIR}/%.pb.gw.go: ${PROTO_DIR}/%.proto
-	protoc -I. --openapi_out=${API_DIR} --openapi_opt=naming=proto,enum_type=string \
+	protoc --experimental_allow_proto3_optional -I. --openapi_out=${API_DIR} --openapi_opt=naming=proto,enum_type=string \
 		--go_out=${API_DIR} --go_opt=paths=source_relative \
 		--go-grpc_out=${API_DIR} --go-grpc_opt=require_unimplemented_servers=false,paths=source_relative \
 		--grpc-gateway_out=${API_DIR} --grpc-gateway_opt=paths=source_relative,allow_delete_body=true \

--- a/server/v1/api.proto
+++ b/server/v1/api.proto
@@ -396,13 +396,13 @@ message FacetCount {
 // Additional stats for faceted field
 message FacetStats {
   // Average of all values in a field. Only available for numeric fields
-  double avg = 1;
+  optional double avg = 1;
   // Maximum of all values in a field. Only available for numeric fields
-  double max = 2;
+  optional double max = 2;
   // Minimum of all values in a field. Only available for numeric fields
-  double min = 3;
+  optional double min = 3;
   // Sum of all values in a field. Only available for numeric fields
-  double sum = 4;
+  optional double sum = 4;
   // Total number of values in a field
   int64 count = 5;
 }


### PR DESCRIPTION
These optional fields need to be present when faceting over numeric fields.