### PR TITLE
Do not expose events API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ endif
 
 all: lint
 
-.PRECIOUS: ${PROTO_DIR}/%_openapi.yaml ${PROTO_DIR}/%.proto
+.PRECIOUS: ${PROTO_DIR}/openapi.yaml ${PROTO_DIR}/%.proto
 
-COMPONENTS = api health admin auth observability management
+COMPONENTS = api health auth observability management
 
 # Generate GRPC client/server, openapi spec, http server
 ${GEN_DIR}/%.pb.go ${GEN_DIR}/%.pb.gw.go: ${PROTO_DIR}/%.proto

--- a/scripts/fix_openapi.sh
+++ b/scripts/fix_openapi.sh
@@ -80,6 +80,10 @@ main() {
 	yq_streaming_response SubscribeResponse "collections/{collection}/messages/subscribe"
 
 	yq_error_response
+
+	# Do not expose "events" endpint in openapi
+	# TODO: Remove it once events endpoint is fixed
+	yq_cmd 'del(.paths."/v1/databases/{db}/collections/{collection}/events")'
 }
 
 fix_bytes() {

--- a/server/v1/openapi.yaml
+++ b/server/v1/openapi.yaml
@@ -462,46 +462,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/databases/{db}/collections/{collection}/events:
-        post:
-            tags:
-                - Collections
-            summary: Change Events
-            description: |-
-                Stream real-time events for mutations made to the collections in the database. Each stream will have a transaction
-                 identifier attached to it and will have a boolean flag “last” set to the last event of the transaction which will be useful
-                 if a transaction performed more than one operation in the collection.
-            operationId: Tigris_Events
-            parameters:
-                - name: db
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-                - name: collection
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/EventsRequest'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/StreamingEventsResponse'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
     /v1/databases/{db}/collections/{collection}/messages/publish:
         post:
             tags:


### PR DESCRIPTION
* Do not depend on "admin" service generated files
  So as some of them are not generated, generate target
  run every time
