### PR TITLE
fix: Simplified namespace API

### DIFF
--- a/server/v1/management.proto
+++ b/server/v1/management.proto
@@ -28,7 +28,7 @@ message CreateNamespaceRequest {
   // Optional: unique string id
   string id = 2;
   // Required: The display name for namespace.
-  string display_name = 3;
+  string name = 3;
 }
 
 message CreateNamespaceResponse {
@@ -41,12 +41,12 @@ message CreateNamespaceResponse {
 }
 
 message NamespaceInfo {
-  // The unique namespace id.
-  int32 id = 1;
-  // The namespace name.
-  string name = 2;
+  // The unique namespace code.
+  int32 code = 1;
+  // The namespace unique id.
+  string id = 2;
   // The namespace display name.
-  string display_name = 3;
+  string name = 3;
 }
 
 message ListNamespacesRequest {

--- a/server/v1/openapi.yaml
+++ b/server/v1/openapi.yaml
@@ -1278,7 +1278,7 @@ components:
                 id:
                     type: string
                     description: 'Optional: unique string id'
-                display_name:
+                name:
                     type: string
                     description: 'Required: The display name for namespace.'
         CreateNamespaceResponse:
@@ -1718,14 +1718,14 @@ components:
         NamespaceInfo:
             type: object
             properties:
-                id:
+                code:
                     type: integer
-                    description: The unique namespace id.
+                    description: The unique namespace code.
                     format: int32
-                name:
+                id:
                     type: string
-                    description: The namespace name.
-                display_name:
+                    description: The namespace unique id.
+                name:
                     type: string
                     description: The namespace display name.
         Page:


### PR DESCRIPTION
- Missed to update NamespaceInfo in last PR.
- Renamed `display_name` to `name`.