### PR TITLE
refactor: Renamed response field name

### DIFF
--- a/server/v1/cache.proto
+++ b/server/v1/cache.proto
@@ -95,7 +95,7 @@ message ListCachesRequest {
 
 message ListCachesResponse {
   // List of caches metadata
-  repeated CacheMetadata cachesMetadata = 1;
+  repeated CacheMetadata caches = 1;
 }
 
 message CacheMetadata {

--- a/server/v1/openapi.yaml
+++ b/server/v1/openapi.yaml
@@ -2545,7 +2545,7 @@ components:
         ListCachesResponse:
             type: object
             properties:
-                cachesMetadata:
+                caches:
                     type: array
                     items:
                         $ref: '#/components/schemas/CacheMetadata'


### PR DESCRIPTION
Renamed `cachesMetadata` to `caches` for ListCaches RPC method.