### PR TITLE
refactor: Removed kv from cache operation path

### DIFF
--- a/server/v1/cache.proto
+++ b/server/v1/cache.proto
@@ -204,7 +204,7 @@ service Cache {
 
   rpc Set(SetRequest) returns (SetResponse) {
     option (google.api.http) = {
-      post : "/v1/projects/{project}/caches/{name}/kv/{key}/set"
+      post : "/v1/projects/{project}/caches/{name}/{key}/set"
       body : "*"
     };
     option(openapi.v3.operation) = {
@@ -215,7 +215,7 @@ service Cache {
 
   rpc GetSet(GetSetRequest) returns (GetSetResponse) {
     option (google.api.http) = {
-      post : "/v1/projects/{project}/caches/{name}/kv/{key}/getset"
+      post : "/v1/projects/{project}/caches/{name}/{key}/getset"
       body : "*"
     };
     option(openapi.v3.operation) = {
@@ -226,7 +226,7 @@ service Cache {
 
   rpc Get(GetRequest) returns (GetResponse) {
     option (google.api.http) = {
-      get : "/v1/projects/{project}/caches/{name}/kv/{key}/get"
+      get : "/v1/projects/{project}/caches/{name}/{key}/get"
     };
     option(openapi.v3.operation) = {
       summary: "Reads an entry from cache"
@@ -236,7 +236,7 @@ service Cache {
 
   rpc Del(DelRequest) returns (DelResponse) {
     option (google.api.http) = {
-      delete : "/v1/projects/{project}/caches/{name}/kv/{key}/delete"
+      delete : "/v1/projects/{project}/caches/{name}/{key}/delete"
       body : "*"
     };
     option(openapi.v3.operation) = {
@@ -247,7 +247,7 @@ service Cache {
 
   rpc Keys(KeysRequest) returns (stream KeysResponse) {
     option (google.api.http) = {
-      get : "/v1/projects/{project}/caches/{name}/kv/keys"
+      get : "/v1/projects/{project}/caches/{name}/keys"
     };
     option(openapi.v3.operation) = {
       summary: "Lists all the key for this cache"

--- a/server/v1/openapi.yaml
+++ b/server/v1/openapi.yaml
@@ -702,7 +702,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/projects/{project}/caches/{name}/kv/keys:
+    /v1/projects/{project}/caches/{name}/keys:
         get:
             tags:
                 - Cache
@@ -751,7 +751,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/projects/{project}/caches/{name}/kv/{key}/delete:
+    /v1/projects/{project}/caches/{name}/{key}/delete:
         delete:
             tags:
                 - Cache
@@ -795,7 +795,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/projects/{project}/caches/{name}/kv/{key}/get:
+    /v1/projects/{project}/caches/{name}/{key}/get:
         get:
             tags:
                 - Cache
@@ -833,7 +833,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/projects/{project}/caches/{name}/kv/{key}/getset:
+    /v1/projects/{project}/caches/{name}/{key}/getset:
         post:
             tags:
                 - Cache
@@ -877,7 +877,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/projects/{project}/caches/{name}/kv/{key}/set:
+    /v1/projects/{project}/caches/{name}/{key}/set:
         post:
             tags:
                 - Cache


### PR DESCRIPTION
## Describe your changes
 - Removed `kv` from path for cache operations.
 - all the cache related operations will be added under the same http path.

## How best to test these changes
 - n/a
 
## Issue ticket number and link
