### PR TITLE
refactor: Support describe, list and info at the same URL

### DIFF
--- a/scripts/fix_openapi.sh
+++ b/scripts/fix_openapi.sh
@@ -99,8 +99,6 @@ main() {
 		yq_del_project_cache_key $i
 	done
 
-	## fix the additionalBindings
-	yq_fix_management_list_namespaces
 }
 
 fix_bytes() {
@@ -213,11 +211,6 @@ yq_del_project_cache() {
 yq_del_project_cache_key() {
   yq_del_project_cache "$1"
 	yq_cmd "del(.components.schemas.$1.properties.key)"
-}
-
-# Fixes the list namespaces API's additional bindings
-yq_fix_management_list_namespaces() {
-  yq_cmd ".paths./v1/management/namespaces.\$ref = \"#/paths//v1/management/namespaces/{namespace_id}\""
 }
 
 

--- a/scripts/fix_openapi.sh
+++ b/scripts/fix_openapi.sh
@@ -98,6 +98,9 @@ main() {
 	for i in SetRequest GetSetRequest GetRequest DelRequest; do
 		yq_del_project_cache_key $i
 	done
+
+	## fix the additionalBindings
+	yq_fix_management_list_namespaces
 }
 
 fix_bytes() {
@@ -211,5 +214,11 @@ yq_del_project_cache_key() {
   yq_del_project_cache "$1"
 	yq_cmd "del(.components.schemas.$1.properties.key)"
 }
+
+# Fixes the list namespaces API's additional bindings
+yq_fix_management_list_namespaces() {
+  yq_cmd ".paths./v1/management/namespaces.\$ref = \"#/paths//v1/management/namespaces/{namespace_id}\""
+}
+
 
 main

--- a/server/v1/management.proto
+++ b/server/v1/management.proto
@@ -54,17 +54,16 @@ message DescribeNamespacesData {
 }
 
 message ListNamespacesRequest {
+  // Optionally specify if the description of each namespace is requested
+  optional bool describe = 1;
+  // Optionally filter by specific namespaceId
+  string namespace_id = 2;
 }
 
 message ListNamespacesResponse {
   repeated NamespaceInfo namespaces = 1;
-}
+  optional DescribeNamespacesData data = 2;
 
-message DescribeNamespacesRequest {
-}
-
-message DescribeNamespacesResponse {
-  DescribeNamespacesData data = 1;
 }
 
 message NamespaceInfoRequest{
@@ -171,39 +170,18 @@ service Management {
     };
   }
 
-  // Get details for all namespaces
-  rpc DescribeNamespaces(DescribeNamespacesRequest) returns
-      (DescribeNamespacesResponse) {
-    option (google.api.http) = {
-      post : "/v1/management/namespaces/describe"
-    };
-    option(openapi.v3.operation) = {
-      summary: "Describe the details of all namespaces"
-      tags: "Management"
-    };
-  }
-
-  // List all namespace
+  // List all namespace and optionally lists specific namespace by namespaceId filter, also supports `describe` request.
   rpc ListNamespaces(ListNamespacesRequest) returns
       (ListNamespacesResponse) {
     option (google.api.http) = {
-      post : "/v1/management/namespaces/list"
+      get : "/v1/management/namespaces/{namespace_id}"
+      additional_bindings {
+        get : "/v1/management/namespaces"
+      }
     };
+
     option(openapi.v3.operation) = {
       summary: "Lists all Namespaces"
-      tags: "Management"
-    };
-  }
-
-  // Gets the namespace info for specific namespace
-  rpc NamespaceInfo(NamespaceInfoRequest) returns
-      (NamespaceInfoResponse) {
-    option (google.api.http) = {
-      post : "/v1/management/namespaces/info"
-      body : "*"
-    };
-    option(openapi.v3.operation) = {
-      summary: "Retrieves the namespace"
       tags: "Management"
     };
   }

--- a/server/v1/openapi.yaml
+++ b/server/v1/openapi.yaml
@@ -2423,8 +2423,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/management/namespaces:
-        $ref: '#/paths//v1/management/namespaces/{namespace_id}'
 components:
     schemas:
         AdditionalFunction:

--- a/server/v1/openapi.yaml
+++ b/server/v1/openapi.yaml
@@ -187,59 +187,25 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
-    /v1/management/namespaces/describe:
-        post:
-            tags:
-                - Management
-            summary: Describe the details of all namespaces
-            description: Get details for all namespaces
-            operationId: Management_DescribeNamespaces
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/DescribeNamespacesResponse'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/management/namespaces/info:
-        post:
-            tags:
-                - Management
-            summary: Retrieves the namespace
-            description: Gets the namespace info for specific namespace
-            operationId: Management_NamespaceInfo
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/NamespaceInfoRequest'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/NamespaceInfoResponse'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/management/namespaces/list:
-        post:
+    /v1/management/namespaces/{namespace_id}:
+        get:
             tags:
                 - Management
             summary: Lists all Namespaces
-            description: List all namespace
+            description: List all namespace and optionally lists specific namespace by namespaceId filter, also supports `describe` request.
             operationId: Management_ListNamespaces
+            parameters:
+                - name: namespace_id
+                  in: path
+                  description: Optionally filter by specific namespaceId
+                  required: true
+                  schema:
+                    type: string
+                - name: describe
+                  in: query
+                  description: Optionally specify if the description of each namespace is requested
+                  schema:
+                    type: boolean
             responses:
                 "200":
                     description: OK
@@ -2457,6 +2423,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
+    /v1/management/namespaces:
+        $ref: '#/paths//v1/management/namespaces/{namespace_id}'
 components:
     schemas:
         AdditionalFunction:
@@ -3045,11 +3013,6 @@ components:
             properties:
                 details:
                     type: string
-        DescribeNamespacesResponse:
-            type: object
-            properties:
-                data:
-                    $ref: '#/components/schemas/DescribeNamespacesData'
         DocStatus:
             type: object
             properties:
@@ -3499,6 +3462,8 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/NamespaceInfo'
+                data:
+                    $ref: '#/components/schemas/DescribeNamespacesData'
         ListProjectsResponse:
             type: object
             properties:
@@ -3594,17 +3559,6 @@ components:
                 name:
                     type: string
                     description: The namespace display name.
-        NamespaceInfoRequest:
-            type: object
-            properties:
-                id:
-                    type: string
-                    description: namespace id
-        NamespaceInfoResponse:
-            type: object
-            properties:
-                namespace_info:
-                    $ref: '#/components/schemas/NamespaceInfo'
         Page:
             type: object
             properties:


### PR DESCRIPTION
## Describe your changes
For namespace management operations support describe, list and info at the same URL

Note:

For additional_binding in openapi.yaml - it is left out for now because
 - approach with $ref is not supported in redocly
 - approach with duplicate block complains about duplicate operationId
 - approach with overriding operationId will not match the gRPC method name.

## How best to test these changes

## Issue ticket number and link
